### PR TITLE
Fix minutes display condition in time formatting

### DIFF
--- a/src/Interface/Tabs/Map.as
+++ b/src/Interface/Tabs/Map.as
@@ -250,7 +250,7 @@ class MapTab : Tab
         int minutes = (time / 60) % 60;
         int seconds = time % 60;
 
-        return (hours != 0 ? Text::Format("%02d", hours) + ":" : "" ) + (minutes != 0 ? Text::Format("%02d", minutes) + ":" : "") + Text::Format("%02d", seconds) + "." + Text::Format("%03d", hundreths);
+        return (hours != 0 ? Text::Format("%02d", hours) + ":" : "" ) + (minutes != 0 || hours != 0 ? Text::Format("%02d", minutes) + ":" : "") + Text::Format("%02d", seconds) + "." + Text::Format("%03d", hundreths);
     }
 
     void Render() override


### PR DESCRIPTION
I saw that records with times like `2:00:30.069` were displayed as `2:30.069` (example found [here](https://trackmania.exchange/maps/73418)).
This could fix it, but I have no environment to test it.