### PR TITLE
Added "Award this map on TMX"

### DIFF
--- a/src/Interface/Tabs/Map.as
+++ b/src/Interface/Tabs/Map.as
@@ -406,12 +406,7 @@ class MapTab : Tab
         UI::Text(Icons::Money + " \\$f77" + m_map.DisplayCost);
         UI::SetPreviousTooltip("Coppers cost");
 
-        /* Inlined styles, because this is the only place where a gold button is needed */
-        UI::PushStyleColor(UI::Col::Button, UI::HSV(0.12f, 1, 0.7f));
-        UI::PushStyleColor(UI::Col::ButtonHovered, UI::HSV(0.12f, 1.1f, 0.8f));
-        UI::PushStyleColor(UI::Col::ButtonActive, UI::HSV(0.12f, 1.2f, 0.9f));
-        if (UI::Button(Icons::Trophy + " Award this map on "+shortMXName)) OpenBrowserURL("https://"+MXURL+"/maps/"+m_map.TrackID+"#award");
-        UI::PopStyleColor(3);
+        if (UI::GoldButton(Icons::Trophy + " Award this map on "+shortMXName)) OpenBrowserURL("https://"+MXURL+"/maps/"+m_map.TrackID+"#award");
 
         if (UI::CyanButton(Icons::ExternalLink + " View on "+pluginName)) OpenBrowserURL("https://"+MXURL+"/maps/"+m_map.TrackID);
 #if TMNEXT

--- a/src/Interface/Tabs/Map.as
+++ b/src/Interface/Tabs/Map.as
@@ -405,6 +405,14 @@ class MapTab : Tab
         UI::SetPreviousTooltip("Mood");
         UI::Text(Icons::Money + " \\$f77" + m_map.DisplayCost);
         UI::SetPreviousTooltip("Coppers cost");
+
+        /* Inlined styles, because this is the only place where a gold button is needed */
+        UI::PushStyleColor(UI::Col::Button, UI::HSV(0.12f, 1, 0.7f));
+        UI::PushStyleColor(UI::Col::ButtonHovered, UI::HSV(0.12f, 1.1f, 0.8f));
+        UI::PushStyleColor(UI::Col::ButtonActive, UI::HSV(0.12f, 1.2f, 0.9f));
+        if (UI::Button(Icons::Trophy + " Award this map on "+shortMXName)) OpenBrowserURL("https://"+MXURL+"/maps/"+m_map.TrackID+"#award");
+        UI::PopStyleColor(3);
+
         if (UI::CyanButton(Icons::ExternalLink + " View on "+pluginName)) OpenBrowserURL("https://"+MXURL+"/maps/"+m_map.TrackID);
 #if TMNEXT
         if (UI::Button(Icons::ExternalLink + " View on Trackmania.io")) OpenBrowserURL("https://trackmania.io/#/leaderboard/"+m_map.TrackUID);
@@ -517,7 +525,7 @@ class MapTab : Tab
         UI::BeginChild("Description");
 
         UI::PushFont(g_fontHeader);
-        UI::Text(ColoredString(m_map.GbxMapName));
+        UI::TextWrapped(ColoredString(m_map.GbxMapName));
         UI::PopFont();
 
         if (m_authorsError) {

--- a/src/Utils/UI/ColoredButton.as
+++ b/src/Utils/UI/ColoredButton.as
@@ -17,4 +17,5 @@ namespace UI
     bool PurpleButton(const string &in text) { return ColoredButton(text, 0.8f); }
     bool RoseButton(const string &in text) { return ColoredButton(text, 0.9f); }
     bool YellowButton(const string &in text) { return ColoredButton(text, 0.2f); }
+    bool GoldButton(const string &in text) { return ColoredButton(text, 0.12f, 1.f, 0.7f); }
 }


### PR DESCRIPTION
tldr:
- added award this map on TMX button to the button list on a map page
- changed map name from `UI::Text` to `UI::TextWrapped`

On maps tabs, I added a "Award this map on TMX" button. The button leads them to the map page like usual, but with a `#award` hash, which makes a pop-up show up prompting them to award the map. The main benefit of this is the reminder to award a map, as it's a good way to somewhat support a mapper. 

And I noticed the map name was `Text` instead of `TextWrapped`, which made long names clip outside of the window instead of wrap, so I changed that as well (during my attempts at finding a decent spot for the award button).