### PR TITLE
Fix downloaded maps being saved as ".Map.Gbx" overwriting eachother

### DIFF
--- a/src/Utils/MX/Methods.as
+++ b/src/Utils/MX/Methods.as
@@ -140,7 +140,7 @@ namespace MX
             }
             mapDownloadInProgress = false;
 
-            if (fileName.Length > 0) fileName = map.TrackID + " - " + map.Name;
+            if (fileName.Length == 0) fileName = map.TrackID + " - " + map.Name;
             netMap.SaveToFile(mxDLFolder + "/" + fileName + ".Map.Gbx");
             print("Map downloaded to " + mxDLFolder + "/" + fileName + ".Map.Gbx");
         } catch {


### PR DESCRIPTION
Fixed an incorrect comparison with fileName.Length (the generated name should be used if the current fileName is empty)