### PR TITLE
Makes MP4 use SingleMap as the gamemode for playing a map instead of the engine's fallback

### DIFF
--- a/src/Utils/MX/Methods.as
+++ b/src/Utils/MX/Methods.as
@@ -131,7 +131,17 @@ namespace MX
                     && Permissions::OpenAdvancedMapEditor()
 #endif
                 ) app.ManiaTitleControlScriptAPI.EditMap("https://"+MXURL+"/maps/download/"+mapId, "", "");
+#if !MP4
                 else app.ManiaTitleControlScriptAPI.PlayMap("https://"+MXURL+"/maps/download/"+mapId, Mode, "");
+#else
+                else {
+                    if (Mode == "" && repo == MP4mxRepos::Trackmania) {
+                        Mode = "SingleMap";
+                    }
+                    app.ManiaTitleControlScriptAPI.PlayMap("https://"+MXURL+"/maps/download/"+mapId, Mode, "");
+                }
+#endif
+
 #if TMNEXT
             } else mxError("You don't have permission to play custom maps.", true);
 #endif


### PR DESCRIPTION
This is functionally just a port of our PR from the MXRandom repo (GreepTheSheep/openplanet-MXRandom#109).

We go a bit more in depth in that PR, but the tl;dr is that the plugin currently does not load any explicit gamemode. Rather, it loads the engine's fallback gamemode, which causes a variety of funky behavior, such as the game displaying MP3's UI, as MP4's UI is driven largely by Nadeo's base gamemode scripts, which the engine's fallback does not load.

So this PR is a straight-forward fix; in LoadMap() for MP4, if there's no mode defined by the time the function is about to call `PlayMap()`, then it'll set the mode to `SingleMap`, which is the mode that Nadeo's maniascript generally tries to enforce as a default (such as when loading a map through the menus). This in turn makes the play map button behave more or less the same as playing a map you've downloaded locally, which in turn lines up a lot better with how players would likely expect the plugin to work.

(As a side note: since this plugin supports Shootmania, and Singlemap simply does not exist in Shootmania, this only applies if Trackmania's exchange is currently active. Though since most SM modes are already defined in `ModesFromMapTypes.as`, this probably doesn't affect much either way.)