### PR TITLE
Fix MP4 latest tab and JSON parsing for some classes

### DIFF
--- a/src/Interface/Tabs/Map.as
+++ b/src/Interface/Tabs/Map.as
@@ -501,7 +501,7 @@ class MapTab : Tab
             }
         } else {
 #if TMNEXT
-            if (Permissions::PlayLocalMap() && UI::RedButton(Icons::Check + " Remove from Play later")) {
+            if (Permissions::PlayLocalMap() && UI::RedButton(Icons::Times + " Remove from Play later")) {
 #else
             if (UI::RedButton(Icons::Times + " Remove from Play later")) {
 #endif

--- a/src/Interface/Tabs/MapList.as
+++ b/src/Interface/Tabs/MapList.as
@@ -5,7 +5,7 @@ class MapListTab : Tab
     uint totalItems = 0;
     bool m_useRandom = false;
     bool m_firstLoad = true;
-    int m_selectedEnviroId = 0;
+    int m_selectedEnviroId = -1;
     string m_selectedEnviroName = "Any";
     int m_page = 1;
 
@@ -14,7 +14,7 @@ class MapListTab : Tab
         params.Set("api", "on");
         params.Set("format", "json");
         params.Set("limit", "100");
-        params.Set("environments", tostring(m_selectedEnviroId));
+        if (m_selectedEnviroName != "Any") params.Set("environments", tostring(m_selectedEnviroId));
         params.Set("page", tostring(m_page));
         if (m_useRandom) {
             params.Set("random", "1");

--- a/src/Utils/MX/Classes/MapInfo.as
+++ b/src/Utils/MX/Classes/MapInfo.as
@@ -126,7 +126,10 @@ namespace MX
                 json["AwardCount"] = AwardCount;
                 json["ReplayCount"] = ReplayCount;
                 json["ImageCount"] = ImageCount;
+                json["EmbeddedObjectsCount"] = EmbeddedObjectsCount;
+                json["EmbeddedItemsSize"] = EmbeddedItemsSize;
                 json["IsMP4"] = IsMP4;
+                json["SizeWarning"] = SizeWarning;
 
                 string tagsStr = "";
                 for (uint i = 0; i < Tags.Length; i++)

--- a/src/Utils/MX/Classes/UserInfo.as
+++ b/src/Utils/MX/Classes/UserInfo.as
@@ -16,7 +16,7 @@ namespace MX
         int AwardsGiven;
         int CommentsReceived;
         int CommentsGiven;
-        int FavouritesCount;
+        int FavouritesReceivedCount;
         int FavouritesGivenCount;
         int VideosReceivedCount;
         int VideosSubmittedCount;
@@ -42,7 +42,7 @@ namespace MX
                 AwardsGiven = json["AwardsGiven"];
                 CommentsReceived = json["CommentsReceived"];
                 CommentsGiven = json["CommentsGiven"];
-                FavouritesCount = json["FavouritesCount"];
+                FavouritesReceivedCount = json["FavouritesReceivedCount"];
                 FavouritesGivenCount = json["FavouritesGivenCount"];
                 VideosReceivedCount = json["VideosReceivedCount"];
                 VideosSubmittedCount = json["VideosSubmittedCount"];
@@ -74,7 +74,7 @@ namespace MX
                 json["AwardsGiven"] = AwardsGiven;
                 json["CommentsReceived"] = CommentsReceived;
                 json["CommentsGiven"] = CommentsGiven;
-                json["FavouritesCount"] = FavouritesCount;
+                json["FavouritesReceivedCount"] = FavouritesReceivedCount;
                 json["FavouritesGivenCount"] = FavouritesGivenCount;
                 json["VideosReceivedCount"] = VideosReceivedCount;
                 json["VideosSubmittedCount"] = VideosSubmittedCount;

--- a/src/Utils/MX/Methods.as
+++ b/src/Utils/MX/Methods.as
@@ -52,7 +52,8 @@ namespace MX
         m_environments.InsertLast(Environment(1, "Stadium"));
 #else
         if (repo == MP4mxRepos::Trackmania) {
-            m_environments.InsertLast(Environment(0, "Any"));
+            m_environments.InsertLast(Environment(-1, "Any"));
+            m_environments.InsertLast(Environment(0, "Custom"));
             m_environments.InsertLast(Environment(1, "Canyon"));
             m_environments.InsertLast(Environment(2, "Stadium"));
             m_environments.InsertLast(Environment(3, "Valley"));

--- a/src/Utils/NadeoServices/ClubRoom.as
+++ b/src/Utils/NadeoServices/ClubRoom.as
@@ -68,10 +68,13 @@ namespace NadeoServices
                 playerCount = json["playerCount"];
                 script = json["script"];
                 scalable = json["scalable"];
-                joinLink = json["serverInfo"]["joinLink"];
-                currentMapUid = json["serverInfo"]["currentMapUid"];
-                starting = json["serverInfo"]["starting"];
                 if (json["scriptSettings"].HasKey("S_TimeLimit")) timeLimit = json["scriptSettings"]["S_TimeLimit"]["value"];
+
+                if (json["serverInfo"].GetType() != Json::Type::Null) {
+                    joinLink = json["serverInfo"]["joinLink"];
+                    currentMapUid = json["serverInfo"]["currentMapUid"];
+                    starting = json["serverInfo"]["starting"];
+                }
 
                 for (uint i = 0; i < json["maps"].Length; i++)
                     maps.InsertLast(json["maps"][i]);

--- a/src/Utils/NadeoServices/ClubRoom.as
+++ b/src/Utils/NadeoServices/ClubRoom.as
@@ -68,10 +68,10 @@ namespace NadeoServices
                 playerCount = json["playerCount"];
                 script = json["script"];
                 scalable = json["scalable"];
-                if (json["scriptSettings"]["S_TimeLimit"].GetType() != Json::Type::Null) timeLimit = json["scriptSettings"]["S_TimeLimit"]["value"];
                 joinLink = json["serverInfo"]["joinLink"];
                 currentMapUid = json["serverInfo"]["currentMapUid"];
                 starting = json["serverInfo"]["starting"];
+                if (json["scriptSettings"].HasKey("S_TimeLimit")) timeLimit = json["scriptSettings"]["S_TimeLimit"]["value"];
 
                 for (uint i = 0; i < json["maps"].Length; i++)
                     maps.InsertLast(json["maps"][i]);


### PR DESCRIPTION
* The plugin sets the environment "Any" (ID 0) as the default one when searching maps on MP4. In the [TMX API documentation](https://api2.mania.exchange/Enum/Index/2), the enum value 0 is used for custom environments, which shows only 1 map (see #24). This requires to add another environment for "Any" with ID -1, and check the environment before adding the parameter

* Adds missing values for the MapInfo JSON, so the PlayLater file can be parsed correctly (see #23)

* User info parsing was broken due to a wrong (or outdated) key value. Changing this to the correct name allows the plugin to load the JSON correctly

* Changes S_TimeLimit key check in ClubRoom class to .HasKey, since some servers don't set this setting

* Check if serverInfo is not null in club room JSON before accessing it

* Use correct icon for "Remove from Play later" button

Fixes #23
Fixes #24