### PR TITLE
Add missing gamemodes, UI fixes/improvements, other fixes

### DIFF
--- a/src/Interface/ModalDialogs/MapPackActionWarn.as
+++ b/src/Interface/ModalDialogs/MapPackActionWarn.as
@@ -48,7 +48,7 @@ class MapPackActionWarn : ModalDialog
                 case MapPackActions::Download:
                     for (uint i = 0; i < mapPack_maps.Length; i++) {
                         MX::MapInfo@ map = mapPack_maps[i];
-                        UI::ShowNotification("Downloading map...", ColoredString(map.GbxMapName) + "\\$z\\$s by " + map.Username);
+                        UI::ShowNotification("Downloading map...", Text::OpenplanetFormatCodes(map.GbxMapName) + "\\$z\\$s by " + map.Username);
                         startnew(CoroutineFunc(map.DownloadMap));
                     }
                     break;

--- a/src/Interface/ModalDialogs/PlayMapOnNadeoRoomInfos.as
+++ b/src/Interface/ModalDialogs/PlayMapOnNadeoRoomInfos.as
@@ -79,7 +79,7 @@ class PlayMapOnNadeoRoomInfos : ModalDialog
 
         if (TMNext::foundRoom !is null) {
             UI::Text("Room found:");
-            UI::Text("'"+TMNext::foundRoom.name+"', in club '"+StripFormatCodes(TMNext::foundRoom.clubName)+"'");
+            UI::Text("'"+TMNext::foundRoom.name+"', in club '"+Text::StripFormatCodes(TMNext::foundRoom.clubName)+"'");
 
             if (!TMNext::foundRoom.nadeo) {
                 UI::Text("\\$f20" + Icons::ExclamationTriangle + " this server is NOT hosted by Nadeo, so you can't add maps from this plugin");

--- a/src/Interface/Render/MapPackResult.as
+++ b/src/Interface/Render/MapPackResult.as
@@ -5,6 +5,7 @@ namespace IfaceRender
         UI::TableNextRow();
 
         UI::TableSetColumnIndex(0);
+        UI::AlignTextToFramePadding();
         UI::Text(mapPack.Name);
         UI::MXMapPackThumbnailTooltip(mapPack.ID);
         if (UI::IsItemClicked()) mxMenu.AddTab(MapPackTab(mapPack.ID), true);

--- a/src/Interface/Render/MapPackResult.as
+++ b/src/Interface/Render/MapPackResult.as
@@ -17,7 +17,6 @@ namespace IfaceRender
 
         UI::TableSetColumnIndex(2);
         if (mapPack.Tags.Length == 0) UI::Text("No tags");
-        else if (mapPack.Tags.Length == 1) UI::Text(mapPack.Tags[0].Name);
         else{
             for (uint i = 0; i < mapPack.Tags.Length; i++) {
                 IfaceRender::MapTag(mapPack.Tags[i]);

--- a/src/Interface/Render/MapResult.as
+++ b/src/Interface/Render/MapResult.as
@@ -5,6 +5,7 @@ namespace IfaceRender
         UI::TableNextRow();
 
         UI::TableSetColumnIndex(0);
+        UI::AlignTextToFramePadding();
         if (Setting_ColoredMapName) UI::Text(Text::OpenplanetFormatCodes(map.GbxMapName));
         else UI::Text(map.Name);
         UI::MXMapThumbnailTooltip(map.TrackID);

--- a/src/Interface/Render/MapResult.as
+++ b/src/Interface/Render/MapResult.as
@@ -5,7 +5,7 @@ namespace IfaceRender
         UI::TableNextRow();
 
         UI::TableSetColumnIndex(0);
-        if (Setting_ColoredMapName) UI::Text(ColoredString(map.GbxMapName));
+        if (Setting_ColoredMapName) UI::Text(Text::OpenplanetFormatCodes(map.GbxMapName));
         else UI::Text(map.Name);
         UI::MXMapThumbnailTooltip(map.TrackID);
         if (UI::IsItemClicked()) mxMenu.AddTab(MapTab(map.TrackID), true);
@@ -45,7 +45,7 @@ namespace IfaceRender
 #endif
             if (UI::GreenButton(Icons::Play)) {
                 if (UI::IsOverlayShown() && Setting_CloseOverlayOnLoad) UI::HideOverlay();
-                UI::ShowNotification("Loading map...", ColoredString(map.GbxMapName) + "\\$z\\$s by " + map.Username);
+                UI::ShowNotification("Loading map...", Text::OpenplanetFormatCodes(map.GbxMapName) + "\\$z\\$s by " + map.Username);
                 MX::mapToLoad = map.TrackID;
             }
 
@@ -56,7 +56,7 @@ namespace IfaceRender
 #endif
             if (UI::OrangeButton(Icons::Play)) {
                 if (UI::IsOverlayShown() && Setting_CloseOverlayOnLoad) UI::HideOverlay();
-                UI::ShowNotification("Loading map...", ColoredString(map.GbxMapName) + "\\$z\\$s by " + map.Username);
+                UI::ShowNotification("Loading map...", Text::OpenplanetFormatCodes(map.GbxMapName) + "\\$z\\$s by " + map.Username);
                 UI::ShowNotification(Icons::ExclamationTriangle + " Warning", "The map type is not supported for direct play, it can crash your game or returns you to the menu", UI::HSV(0.11, 1.0, 1.0), 15000);
                 MX::mapToLoad = map.TrackID;
             }

--- a/src/Interface/Render/MapResult.as
+++ b/src/Interface/Render/MapResult.as
@@ -18,7 +18,6 @@ namespace IfaceRender
 
         UI::TableSetColumnIndex(2);
         if (map.Tags.Length == 0) UI::Text("No tags");
-        else if (map.Tags.Length == 1) UI::Text(map.Tags[0].Name);
         else{
             for (uint i = 0; i < map.Tags.Length; i++) {
                 IfaceRender::MapTag(map.Tags[i]);

--- a/src/Interface/Render/Tags.as
+++ b/src/Interface/Render/Tags.as
@@ -1,6 +1,6 @@
 namespace IfaceRender
 {
-    const vec4 TAG_COLOR         = vec4( 30/255.0f,  32/255.0f,  33/255.0f, 1);
+    const vec4 TAG_COLOR         = vec4( 66/255.0f,  66/255.0f,  66/255.0f, 1);
 
     const vec2 TAG_PADDING = vec2(8, 4);
     const float TAG_ROUNDING = 4;
@@ -29,7 +29,12 @@ namespace IfaceRender
 
     void MapTag(MX::MapTag@ tag)
     {
-        vec4 color = Text::ParseHexColor(tag.Color);
-        IfaceRender::Tag(tag.Name, color);
+        vec4 color;
+
+        if (Text::TryParseHexColor(tag.Color, color)) {
+            IfaceRender::Tag(tag.Name, color);
+        } else {
+            IfaceRender::Tag(tag.Name);
+        }
     }
 }

--- a/src/Interface/Tab.as
+++ b/src/Interface/Tab.as
@@ -15,11 +15,13 @@ class Tab
         UI::PushStyleColor(UI::Col::Tab, color * vec4(0.5f, 0.5f, 0.5f, 0.75f));
         UI::PushStyleColor(UI::Col::TabHovered, color * vec4(1.2f, 1.2f, 1.2f, 0.85f));
         UI::PushStyleColor(UI::Col::TabActive, color);
+        UI::PushStyleColor(UI::Col::TableRowBgAlt, vec4(0.10f, 0.10f, 0.10f, 1));
+        UI::PushStyleColor(UI::Col::TableRowBg, vec4(0.13f, 0.13f, 0.13f, 1));
     }
 
     void PopTabStyle()
     {
-        UI::PopStyleColor(3);
+        UI::PopStyleColor(5);
     }
 
     void Reload() {}

--- a/src/Interface/Tabs/LatestMaps.as
+++ b/src/Interface/Tabs/LatestMaps.as
@@ -5,10 +5,4 @@ class LatestMapsTab : MapListTab
     string GetLabel() override {return Icons::ClockO + " Latest";}
 
     vec4 GetColor() override { return vec4(0.22f, 0.61f, 0.43f, 1); }
-
-    void GetRequestParams(dictionary@ params) override
-    {
-        MapListTab::GetRequestParams(params);
-        params.Set("mode", "2");
-    }
 }

--- a/src/Interface/Tabs/Map.as
+++ b/src/Interface/Tabs/Map.as
@@ -627,7 +627,7 @@ class MapTab : Tab
                         m_replaysstopleaderboard = false;
                         StartMXReplaysRequest();
                     }
-                    if (UI::BeginTable("MXLeaderboardList", 4)) {
+                    if (UI::BeginTable("MXLeaderboardList", 4, UI::TableFlags::RowBg)) {
                         UI::TableSetupScrollFreeze(0, 1);
                         PushTabStyle();
                         UI::TableSetupColumn("Position", UI::TableColumnFlags::WidthFixed, 40);
@@ -709,7 +709,7 @@ class MapTab : Tab
                         UI::Text(Hourglass + " Loading...");
                     }
                 } else {
-                    if (UI::BeginTable("LeaderboardList", 3)) {
+                    if (UI::BeginTable("LeaderboardList", 3, UI::TableFlags::RowBg)) {
                         UI::TableSetupScrollFreeze(0, 1);
                         PushTabStyle();
                         UI::TableSetupColumn("Position", UI::TableColumnFlags::WidthFixed, 40);
@@ -763,7 +763,7 @@ class MapTab : Tab
                 UI::Text(Hourglass + " Loading...");
             } else {
                 UI::Text(m_mapEmbeddedObjects.Length + " objects found, with a total size of " + (m_map.EmbeddedItemsSize / 1024) + " KB");
-                if (UI::BeginTable("EmbeddedObjectsList", 3)) {
+                if (UI::BeginTable("EmbeddedObjectsList", 3, UI::TableFlags::RowBg)) {
                     UI::TableSetupScrollFreeze(0, 1);
                     PushTabStyle();
                     UI::TableSetupColumn("Name", UI::TableColumnFlags::WidthStretch);

--- a/src/Interface/Tabs/Map.as
+++ b/src/Interface/Tabs/Map.as
@@ -49,7 +49,7 @@ class MapTab : Tab
         } else {
             m_isLoading = false;
             string res = Icons::Map+" ";
-            if (Setting_ColoredMapName) res += ColoredString(m_map.GbxMapName);
+            if (Setting_ColoredMapName) res += Text::OpenplanetFormatCodes(m_map.GbxMapName);
             else res += m_map.Name;
             return res;
         }
@@ -429,14 +429,14 @@ class MapTab : Tab
                 }
                 if (Setting_ShowPlayOnAllMaps && UI::OrangeButton(Icons::Play + " Play Map Anyway")) {
                     if (UI::IsOverlayShown() && Setting_CloseOverlayOnLoad) UI::HideOverlay();
-                    UI::ShowNotification("Loading map...", ColoredString(m_map.GbxMapName) + "\\$z\\$s by " + m_map.Username);
+                    UI::ShowNotification("Loading map...", Text::OpenplanetFormatCodes(m_map.GbxMapName) + "\\$z\\$s by " + m_map.Username);
                     UI::ShowNotification(Icons::ExclamationTriangle + " Warning", "The map type is not supported for direct play, it can crash your game or returns you to the menu", UI::HSV(0.11, 1.0, 1.0), 15000);
                     MX::mapToLoad = m_map.TrackID;
                 }
             } else {
                 if (UI::GreenButton(Icons::Play + " Play Map")) {
                     if (UI::IsOverlayShown() && Setting_CloseOverlayOnLoad) UI::HideOverlay();
-                    UI::ShowNotification("Loading map...", ColoredString(m_map.GbxMapName) + "\\$z\\$s by " + m_map.Username);
+                    UI::ShowNotification("Loading map...", Text::OpenplanetFormatCodes(m_map.GbxMapName) + "\\$z\\$s by " + m_map.Username);
                     MX::mapToLoad = m_map.TrackID;
                 }
 #if TMNEXT && DEPENDENCY_NADEOSERVICES
@@ -461,7 +461,7 @@ class MapTab : Tab
 #endif
             if (UI::YellowButton(Icons::Wrench + " Edit Map")) {
                 if (UI::IsOverlayShown() && Setting_CloseOverlayOnLoad) UI::HideOverlay();
-                UI::ShowNotification("Loading map...", ColoredString(m_map.GbxMapName) + "\\$z\\$s by " + m_map.Username);
+                UI::ShowNotification("Loading map...", Text::OpenplanetFormatCodes(m_map.GbxMapName) + "\\$z\\$s by " + m_map.Username);
                 MX::mapToEdit = m_map.TrackID;
             }
 #if TMNEXT
@@ -478,7 +478,7 @@ class MapTab : Tab
             m_isLoading = false;
             if (!m_mapDownloaded) {
                 if (UI::PurpleButton(Icons::Download + " Download Map")) {
-                    UI::ShowNotification("Downloading map...", ColoredString(m_map.GbxMapName) + "\\$z\\$s by " + m_map.Username);
+                    UI::ShowNotification("Downloading map...", Text::OpenplanetFormatCodes(m_map.GbxMapName) + "\\$z\\$s by " + m_map.Username);
                     MX::mapToDL = m_map.TrackID;
                     m_mapDownloaded = true;
                 }
@@ -548,7 +548,7 @@ class MapTab : Tab
         UI::BeginChild("Description");
 
         UI::PushFont(g_fontHeader);
-        UI::TextWrapped(ColoredString(m_map.GbxMapName));
+        UI::TextWrapped(Text::OpenplanetFormatCodes(m_map.GbxMapName));
         UI::PopFont();
 
         if (m_authorsError) {

--- a/src/Interface/Tabs/Map.as
+++ b/src/Interface/Tabs/Map.as
@@ -26,6 +26,7 @@ class MapTab : Tab
     array<MX::MapEmbeddedObject@> m_mapEmbeddedObjects;
     bool m_mapEmbeddedObjectsError = false;
     bool m_replaysError = false;
+    bool m_replaysstopleaderboard = false;
 
     UI::Font@ g_fontHeader;
 
@@ -136,7 +137,7 @@ class MapTab : Tab
 
     void CheckMXReplaysRequest()
     {
-        if (!MX::APIDown && int(m_replays.Length) != (m_map.ReplayCount > 25 ? 25:m_map.ReplayCount) && m_MXReplaysRequest is null && UI::IsWindowAppearing()) {
+        if (!MX::APIDown && !m_replaysstopleaderboard && m_MXReplaysRequest is null && UI::IsWindowAppearing()) {
             StartMXReplaysRequest();
         }
         // If there's a request, check if it has finished
@@ -152,11 +153,16 @@ class MapTab : Tab
                 m_replaysError = true;
                 return;
             }
+            if (m_replays.Length > 0) {
+                // Remove any remaining replays if there's any
+                m_replays.RemoveRange(0, m_replays.Length);
+            }
             // Handle the response
             for (uint i = 0; i < json.Length; i++) {
                 MX::MapReplay@ replay = MX::MapReplay(json[i]);
                 m_replays.InsertLast(replay);
             }
+            m_replaysstopleaderboard = true;
         }
     }
 
@@ -612,6 +618,7 @@ class MapTab : Tab
                     UI::SameLine();
                     if (UI::Button(Icons::Refresh)) {
                         m_replays.RemoveRange(0, m_replays.Length);
+                        m_replaysstopleaderboard = false;
                         StartMXReplaysRequest();
                     }
                     if (UI::BeginTable("MXLeaderboardList", 4)) {

--- a/src/Interface/Tabs/Map.as
+++ b/src/Interface/Tabs/Map.as
@@ -465,7 +465,7 @@ class MapTab : Tab
 #if TMNEXT
         } else {
             UI::Text("\\$f00"+Icons::Times + " \\$zYou do not have permissions to play");
-            UI::Text("Consider buying at least standard access of the game.");
+            UI::Text("Consider buying club access of the game.");
         }
 #endif
 
@@ -479,8 +479,8 @@ class MapTab : Tab
             }
 #if TMNEXT
         } else {
-            UI::Text("\\$f00"+Icons::Times + " \\$zYou do not have permissions to edit map");
-            UI::Text("Consider buying at least standard access of the game.");
+            UI::Text("\\$f00"+Icons::Times + " \\$zYou do not have permissions to edit maps");
+            UI::Text("Consider buying at least club access of the game.");
         }
 #endif
 

--- a/src/Interface/Tabs/Map.as
+++ b/src/Interface/Tabs/Map.as
@@ -447,11 +447,18 @@ class MapTab : Tab
                 }
 #if TMNEXT && DEPENDENCY_NADEOSERVICES
                 if (SupportedModes.HasKey(m_map.MapType) && Permissions::CreateAndUploadMap() && IsInServer()) {
+                    CTrackMania@ app = cast<CTrackMania>(GetApp());
+                    bool sameMapType = CleanMapType(app.RootMap.MapType) == m_map.MapType;
+
+                    UI::BeginDisabled(!sameMapType);
                     if (UI::GreenButton(Icons::Server + " Play Map on Nadeo-hosted Room")) {
                         TMNext::AddMapToServer_MapUid = m_map.TrackUID;
                         TMNext::AddMapToServer_MapMXId = m_map.TrackID;
+                        TMNext::AddMapToServer_MapType = m_map.MapType;
                         Renderables::Add(PlayMapOnNadeoRoomInfos());
                     }
+                    UI::EndDisabled();
+                    if (!sameMapType) UI::SetItemTooltip(Icons::Times + " Map type doesn't match the current room's game mode");
                 }
 #endif
             }

--- a/src/Interface/Tabs/Map.as
+++ b/src/Interface/Tabs/Map.as
@@ -530,28 +530,27 @@ class MapTab : Tab
         }
 
 #if DEPENDENCY_NADEOSERVICES
-        if (m_isMapOnNadeoServices) {
-            if (!m_isMapOnFavorite){
+        if (!m_isMapOnFavorite){
+            UI::BeginDisabled(!m_isMapOnNadeoServices);
 #if TMNEXT
-                if (Permissions::PlayLocalMap() && UI::GreenButton(Icons::Heart + " Add to Favorites")) {
+            if (Permissions::PlayLocalMap() && UI::GreenButton(Icons::Heart + " Add to Favorites")) {
 #else
-                if (UI::GreenButton(Icons::Heart + " Add to Favorites")) {
+            if (UI::GreenButton(Icons::Heart + " Add to Favorites")) {
 #endif
-                    MXNadeoServicesGlobal::m_mapUidToAction = m_map.TrackUID;
-                    startnew(MXNadeoServicesGlobal::AddMapToFavoritesAsync);
-                }
-            } else {
-#if TMNEXT
-                if (Permissions::PlayLocalMap() && UI::RedButton(Icons::Heart + " Remove from Favorites")) {
-#else
-                if (UI::RedButton(Icons::Heart + " Remove from Favorites")) {
-#endif
-                    MXNadeoServicesGlobal::m_mapUidToAction = m_map.TrackUID;
-                    startnew(MXNadeoServicesGlobal::RemoveMapFromFavoritesAsync);
-                }
+                MXNadeoServicesGlobal::m_mapUidToAction = m_map.TrackUID;
+                startnew(MXNadeoServicesGlobal::AddMapToFavoritesAsync);
             }
+            UI::EndDisabled();
+            if (!m_isMapOnNadeoServices) UI::SetItemTooltip(Icons::ExclamationTriangle + " This map is not on Nadeo Services, impossible to add it to favorites");
         } else {
-            UI::TextDisabled(Icons::ExclamationTriangle + " This map is not on Nadeo Services, impossible to add it to favorites");
+#if TMNEXT
+            if (Permissions::PlayLocalMap() && UI::RedButton(Icons::Heart + " Remove from Favorites")) {
+#else
+            if (UI::RedButton(Icons::Heart + " Remove from Favorites")) {
+#endif
+                MXNadeoServicesGlobal::m_mapUidToAction = m_map.TrackUID;
+                startnew(MXNadeoServicesGlobal::RemoveMapFromFavoritesAsync);
+            }
         }
 #endif
 

--- a/src/Interface/Tabs/Map.as
+++ b/src/Interface/Tabs/Map.as
@@ -630,6 +630,7 @@ class MapTab : Tab
                                 MX::MapReplay@ entry = m_replays[i];
 
                                 UI::TableSetColumnIndex(0);
+                                UI::AlignTextToFramePadding();
                                 UI::Text(tostring(entry.Position));
 
                                 UI::TableSetColumnIndex(1);
@@ -710,6 +711,7 @@ class MapTab : Tab
                                 TMIO::Leaderboard@ entry = m_leaderboard[i];
 
                                 UI::TableSetColumnIndex(0);
+                                UI::AlignTextToFramePadding();
                                 UI::Text(tostring(entry.position));
 
                                 UI::TableSetColumnIndex(1);
@@ -764,6 +766,7 @@ class MapTab : Tab
                             UI::PushID("EmbeddedObject" + i);
 
                             UI::TableSetColumnIndex(0);
+                            UI::AlignTextToFramePadding();
                             UI::Text(object.Name);
 
                             UI::TableSetColumnIndex(1);

--- a/src/Interface/Tabs/MapList.as
+++ b/src/Interface/Tabs/MapList.as
@@ -105,19 +105,21 @@ class MapListTab : Tab
 
     void RenderHeader()
     {
-        UI::SetNextItemWidth(150);
-        if (UI::BeginCombo("##EnviroFilter", m_selectedEnviroName)){
-            for (uint i = 0; i < MX::m_environments.Length; i++) {
-                MX::Environment@ envi = MX::m_environments[i];
-                if (UI::Selectable(envi.Name, m_selectedEnviroName == envi.Name)){
-                    m_selectedEnviroName = envi.Name;
-                    m_selectedEnviroId = envi.ID;
-                    Reload();
+        if (MX::m_environments.Length > 1) {
+            UI::SetNextItemWidth(150);
+            if (UI::BeginCombo("##EnviroFilter", m_selectedEnviroName)){
+                for (uint i = 0; i < MX::m_environments.Length; i++) {
+                    MX::Environment@ envi = MX::m_environments[i];
+                    if (UI::Selectable(envi.Name, m_selectedEnviroName == envi.Name)){
+                        m_selectedEnviroName = envi.Name;
+                        m_selectedEnviroId = envi.ID;
+                        Reload();
+                    }
                 }
+                UI::EndCombo();
             }
-            UI::EndCombo();
+            UI::SameLine();
         }
-        UI::SameLine();
         if (UI::GreenButton(Icons::Random + " Random result")){
             m_useRandom = true;
             Reload();

--- a/src/Interface/Tabs/MapList.as
+++ b/src/Interface/Tabs/MapList.as
@@ -7,6 +7,8 @@ class MapListTab : Tab
     bool m_firstLoad = true;
     int m_selectedEnviroId = -1;
     string m_selectedEnviroName = "Any";
+    int m_selectedVehicleId = -1;
+    string m_selectedVehicleName = "Any";
     int m_page = 1;
 
     void GetRequestParams(dictionary@ params)
@@ -15,6 +17,7 @@ class MapListTab : Tab
         params.Set("format", "json");
         params.Set("limit", "100");
         if (m_selectedEnviroName != "Any") params.Set("environments", tostring(m_selectedEnviroId));
+        if (m_selectedVehicleName != "Any") params.Set("vehicles", tostring(m_selectedVehicleId));
         params.Set("page", tostring(m_page));
         if (m_useRandom) {
             params.Set("random", "1");
@@ -65,6 +68,8 @@ class MapListTab : Tab
             if (repo == MP4mxRepos::Shootmania) {
                 m_selectedEnviroName = "Storm";
                 m_selectedEnviroId = 1;
+                m_selectedVehicleName = "StormMan";
+                m_selectedVehicleId = 1;
             }
 #endif
         }
@@ -105,7 +110,11 @@ class MapListTab : Tab
 
     void RenderHeader()
     {
+        UI::AlignTextToFramePadding();
+
         if (MX::m_environments.Length > 1) {
+            UI::Text("Environment:");
+            UI::SameLine();
             UI::SetNextItemWidth(150);
             if (UI::BeginCombo("##EnviroFilter", m_selectedEnviroName)){
                 for (uint i = 0; i < MX::m_environments.Length; i++) {
@@ -113,6 +122,24 @@ class MapListTab : Tab
                     if (UI::Selectable(envi.Name, m_selectedEnviroName == envi.Name)){
                         m_selectedEnviroName = envi.Name;
                         m_selectedEnviroId = envi.ID;
+                        Reload();
+                    }
+                }
+                UI::EndCombo();
+            }
+            UI::SameLine();
+        }
+
+        if (MX::m_vehicles.Length > 1) {
+            UI::Text("Vehicle:");
+            UI::SameLine();
+            UI::SetNextItemWidth(150);
+            if (UI::BeginCombo("##VehicleFilter", m_selectedVehicleName)){
+                for (uint i = 0; i < MX::m_vehicles.Length; i++) {
+                    MX::Vehicle@ vehicle = MX::m_vehicles[i];
+                    if (UI::Selectable(vehicle.Name, m_selectedVehicleName == vehicle.Name)){
+                        m_selectedVehicleName = vehicle.Name;
+                        m_selectedVehicleId = vehicle.ID;
                         Reload();
                     }
                 }

--- a/src/Interface/Tabs/MapList.as
+++ b/src/Interface/Tabs/MapList.as
@@ -162,7 +162,7 @@ class MapListTab : Tab
                 return;
             }
             UI::BeginChild("mapList");
-            if (UI::BeginTable("List", 5)) {
+            if (UI::BeginTable("List", 5, UI::TableFlags::RowBg)) {
                 UI::TableSetupScrollFreeze(0, 1);
                 PushTabStyle();
                 UI::TableSetupColumn("Name", UI::TableColumnFlags::WidthStretch);

--- a/src/Interface/Tabs/MapList.as
+++ b/src/Interface/Tabs/MapList.as
@@ -186,6 +186,7 @@ class MapListTab : Tab
                 if (m_request !is null && totalItems > maps.Length) {
                     UI::TableNextRow();
                     UI::TableSetColumnIndex(0);
+                    UI::AlignTextToFramePadding();
                     UI::Text(Icons::HourglassEnd + " Loading...");
                 }
                 UI::EndTable();

--- a/src/Interface/Tabs/MapPack.as
+++ b/src/Interface/Tabs/MapPack.as
@@ -256,7 +256,7 @@ class MapPackTab : Tab
                     string Hourglass = (HourGlassValue == 0 ? Icons::HourglassStart : (HourGlassValue == 1 ? Icons::HourglassHalf : Icons::HourglassEnd));
                     UI::Text(Hourglass + " Loading...");
                 } else {
-                    if (UI::BeginTable("List", 5)) {
+                    if (UI::BeginTable("List", 5, UI::TableFlags::RowBg)) {
                         UI::TableSetupScrollFreeze(0, 1);
                         PushTabStyle();
                         UI::TableSetupColumn("Name", UI::TableColumnFlags::WidthStretch);

--- a/src/Interface/Tabs/MapPackList.as
+++ b/src/Interface/Tabs/MapPackList.as
@@ -230,6 +230,7 @@ class MapPackListTab : Tab
                 if (m_request !is null && totalItems > mapPacks.Length) {
                     UI::TableNextRow();
                     UI::TableSetColumnIndex(0);
+                    UI::AlignTextToFramePadding();
                     UI::Text(Icons::HourglassEnd + " Loading...");
                 }
                 UI::EndTable();

--- a/src/Interface/Tabs/MapPackList.as
+++ b/src/Interface/Tabs/MapPackList.as
@@ -143,6 +143,7 @@ class MapPackListTab : Tab
             u_typingStart = Time::Now;
             Clear();
         }
+        UI::SetNextItemWidth(150);
         if (UI::BeginCombo("##MapPackFilter", t_selectedFilter)){
             if (UI::Selectable("Latest", t_selectedFilter == "Latest")){
                 t_selectedFilter = "Latest";

--- a/src/Interface/Tabs/MapPackList.as
+++ b/src/Interface/Tabs/MapPackList.as
@@ -207,7 +207,7 @@ class MapPackListTab : Tab
                 return;
             }
             UI::BeginChild("mapList");
-            if (UI::BeginTable("List", 5)) {
+            if (UI::BeginTable("List", 5, UI::TableFlags::RowBg)) {
                 UI::TableSetupScrollFreeze(0, 1);
                 PushTabStyle();
                 UI::TableSetupColumn("Name", UI::TableColumnFlags::WidthStretch);

--- a/src/Interface/Tabs/MostAwardedTab.as
+++ b/src/Interface/Tabs/MostAwardedTab.as
@@ -17,6 +17,7 @@ class MostAwardedTab : MapListTab
 
     void RenderHeader() override
     {
+        UI::SetNextItemWidth(150);
         if (UI::BeginCombo("##MostAwardDateFilter", t_selectedDate)){
             if (UI::Selectable("All Time", t_selectedDate == "All Time")){
                 t_selectedDate = "All Time";

--- a/src/Interface/Tabs/TagsList.as
+++ b/src/Interface/Tabs/TagsList.as
@@ -28,6 +28,15 @@ class TagsListTab : MapListTab
         }
     }
 
+    void StartRequest() override
+    {
+        if (m_selectedTags.Length == 0) {
+            return;
+        }
+
+        MapListTab::StartRequest();
+    }
+
     void RenderHeader() override
     {
         string selectedTagsNames = "";

--- a/src/Interface/Tabs/TagsList.as
+++ b/src/Interface/Tabs/TagsList.as
@@ -5,6 +5,7 @@ class TagsListTab : MapListTab
     string t_selectedSort = "Latest";
     string t_selectedPriord = "-1";
     bool m_tagInclusive = false;
+    bool m_refresh = false;
 
     bool IsVisible() override {return Setting_Tab_Tags_Visible;}
     string GetLabel() override {return Icons::Tags + " Tags";}
@@ -51,7 +52,7 @@ class TagsListTab : MapListTab
                 selectedTagsNames += m_selectedTags[i].Name;
             }
         }
-        if (UI::CollapsingHeader("Tags ("+selectedTagsNames+")##TagsHeader")) {
+        if (UI::CollapsingHeader("Tags ("+selectedTagsNames+")###TagsHeader")) {
             for (uint i = 0; i < MX::m_mapTags.Length; i++) {
                 MX::MapTag@ tag = MX::m_mapTags[i];
                 UI::PushID("TagBtn"+i);
@@ -60,16 +61,19 @@ class TagsListTab : MapListTab
                 if (IsSelected) {
                     if (m_selectedTags.FindByRef(tag) == -1) {
                         m_selectedTags.InsertLast(tag);
-                        Reload();
+                        m_refresh = true;
                     }
                 } else {
                     if (m_selectedTags.FindByRef(tag) != -1) {
                         m_selectedTags.RemoveAt(m_selectedTags.FindByRef(tag));
-                        Reload();
+                        m_refresh = true;
                     }
                 }
                 UI::PopID();
             }
+        } else if (m_refresh) {
+            m_refresh = false;
+            Reload();
         }
         bool selectedTagInc = UI::Checkbox("Tag inclusive search", m_tagInclusive);
         UI::SetPreviousTooltip("If checked, maps must contain all selected tags.");

--- a/src/Interface/Tabs/User.as
+++ b/src/Interface/Tabs/User.as
@@ -598,7 +598,7 @@ class UserTab : Tab
                 string Hourglass = (HourGlassValue == 0 ? Icons::HourglassStart : (HourGlassValue == 1 ? Icons::HourglassHalf : Icons::HourglassEnd));
                 UI::Text(Hourglass + " Loading...");
             } else {
-                if (UI::BeginTable("CreatedMapsList", 5)) {
+                if (UI::BeginTable("CreatedMapsList", 5, UI::TableFlags::RowBg)) {
                     UI::TableSetupScrollFreeze(0, 1);
                     PushTabStyle();
                     UI::TableSetupColumn("Name", UI::TableColumnFlags::WidthStretch);
@@ -644,7 +644,7 @@ class UserTab : Tab
                 string Hourglass = (HourGlassValue == 0 ? Icons::HourglassStart : (HourGlassValue == 1 ? Icons::HourglassHalf : Icons::HourglassEnd));
                 UI::Text(Hourglass + " Loading...");
             } else {
-                if (UI::BeginTable("CreatedMapsList", 5)) {
+                if (UI::BeginTable("CreatedMapsList", 5, UI::TableFlags::RowBg)) {
                     UI::TableSetupScrollFreeze(0, 1);
                     PushTabStyle();
                     UI::TableSetupColumn("Name", UI::TableColumnFlags::WidthStretch);
@@ -690,7 +690,7 @@ class UserTab : Tab
                 string Hourglass = (HourGlassValue == 0 ? Icons::HourglassStart : (HourGlassValue == 1 ? Icons::HourglassHalf : Icons::HourglassEnd));
                 UI::Text(Hourglass + " Loading...");
             } else {
-                if (UI::BeginTable("UserMapPacksList", 5)) {
+                if (UI::BeginTable("UserMapPacksList", 5, UI::TableFlags::RowBg)) {
                     UI::TableSetupScrollFreeze(0, 1);
                     PushTabStyle();
                     UI::TableSetupColumn("Name", UI::TableColumnFlags::WidthStretch);

--- a/src/Interface/Tabs/User.as
+++ b/src/Interface/Tabs/User.as
@@ -665,14 +665,14 @@ class UserTab : Tab
                             UI::PopID();
                         }
                     }
-                    if (m_MXUserMapsCreatedRequest !is null && m_mapsAwardsGivenTotal > m_mapsCreated.Length) {
+                    if (m_MXUserMapsCreatedRequest !is null && m_mapsAwardsGivenTotal > m_mapsAwardsGiven.Length) {
                         UI::TableNextRow();
                         UI::TableSetColumnIndex(0);
                         UI::AlignTextToFramePadding();
                         UI::Text(Icons::HourglassEnd + " Loading...");
                     }
                     UI::EndTable();
-                    if (m_MXUserMapsCreatedRequest is null && m_mapsAwardsGivenTotal > m_mapsCreated.Length && UI::GreenButton("Load more")){
+                    if (m_MXUserMapsCreatedRequest is null && m_mapsAwardsGivenTotal > m_mapsAwardsGiven.Length && UI::GreenButton("Load more")){
                         m_pageAwardedMaps++;
                         StartMXAwardedMapsRequest();
                     }

--- a/src/Interface/Tabs/User.as
+++ b/src/Interface/Tabs/User.as
@@ -519,7 +519,7 @@ class UserTab : Tab
                         UI::SetCursorPos(posTop + vec2(featuredMapwidth + 28, 20));
                         UI::BeginChild("UserFeaturedMapDescriptionChild");
                         UI::PushFont(g_fontHeader);
-                        UI::Text(ColoredString(m_featuredMap.GbxMapName));
+                        UI::Text(Text::OpenplanetFormatCodes(m_featuredMap.GbxMapName));
                         UI::PopFont();
                         if (m_featuredMap.Comments.Length > 100) {
                             IfaceRender::MXComment(m_featuredMap.Comments.SubStr(0, 100) + "...");
@@ -530,7 +530,7 @@ class UserTab : Tab
                         UI::SameLine();
                         if (UI::GreenButton(Icons::Play)) {
                             if (UI::IsOverlayShown() && Setting_CloseOverlayOnLoad) UI::HideOverlay();
-                            UI::ShowNotification("Loading map...", ColoredString(m_featuredMap.GbxMapName) + "\\$z\\$s by " + m_featuredMap.Username);
+                            UI::ShowNotification("Loading map...", Text::OpenplanetFormatCodes(m_featuredMap.GbxMapName) + "\\$z\\$s by " + m_featuredMap.Username);
                             MX::mapToLoad = m_featuredMap.TrackID;
                         }
                         UI::EndChild();

--- a/src/Interface/Tabs/User.as
+++ b/src/Interface/Tabs/User.as
@@ -622,6 +622,7 @@ class UserTab : Tab
                     if (m_MXUserMapsCreatedRequest !is null && m_mapsCreatedTotal > m_mapsCreated.Length) {
                         UI::TableNextRow();
                         UI::TableSetColumnIndex(0);
+                        UI::AlignTextToFramePadding();
                         UI::Text(Icons::HourglassEnd + " Loading...");
                     }
                     UI::EndTable();
@@ -667,6 +668,7 @@ class UserTab : Tab
                     if (m_MXUserMapsCreatedRequest !is null && m_mapsAwardsGivenTotal > m_mapsCreated.Length) {
                         UI::TableNextRow();
                         UI::TableSetColumnIndex(0);
+                        UI::AlignTextToFramePadding();
                         UI::Text(Icons::HourglassEnd + " Loading...");
                     }
                     UI::EndTable();
@@ -712,6 +714,7 @@ class UserTab : Tab
                     if (m_MXUserMapPacksRequest !is null && m_mapPacksTotal > m_mapPacks.Length) {
                         UI::TableNextRow();
                         UI::TableSetColumnIndex(0);
+                        UI::AlignTextToFramePadding();
                         UI::Text(Icons::HourglassEnd + " Loading...");
                     }
                     UI::EndTable();

--- a/src/Interface/Tabs/User.as
+++ b/src/Interface/Tabs/User.as
@@ -445,7 +445,7 @@ class UserTab : Tab
 
         if (!m_isYourProfileTab && Setting_Tab_YourProfile_UserID == 0) {
             UI::Separator();
-            UI::Text(Icons::InfoCircle + " Is this your profile?\nAdd your profile to easily get it from the tabs.");
+            UI::TextWrapped(Icons::InfoCircle + " Is this your profile?\nAdd your profile to easily get it from the tabs.");
             if (UI::GreenButton(Icons::Plus + " Add to your profile")) {
                 Setting_Tab_YourProfile_UserID = m_userId;
             }

--- a/src/Main.as
+++ b/src/Main.as
@@ -52,7 +52,7 @@ void RenderMenuMain(){
 
                 if (currentMapID > 0){
                     UI::Separator();
-                    if (UI::MenuItem(Icons::Kenney::InfoCircle + " " + ColoredString(currentMapInfo.GbxMapName))){
+                    if (UI::MenuItem(Icons::Kenney::InfoCircle + " " + Text::OpenplanetFormatCodes(currentMapInfo.GbxMapName))){
                         if (!Setting_ShowMenu) Setting_ShowMenu = true;
                         mxMenu.AddTab(MapTab(currentMapID), true);
                     }
@@ -102,14 +102,14 @@ void RenderMenuMain(){
             if (g_PlayLaterMaps.Length > 0) {
                 for (uint i = 0; i < g_PlayLaterMaps.Length; i++) {
                     MX::MapInfo@ map = g_PlayLaterMaps[i];
-                    if (UI::BeginMenu((Setting_ColoredMapName ? ColoredString(map.GbxMapName) : map.Name) + " \\$z\\$sby " + map.Username)) {
+                    if (UI::BeginMenu((Setting_ColoredMapName ? Text::OpenplanetFormatCodes(map.GbxMapName) : map.Name) + " \\$z\\$sby " + map.Username)) {
 #if TMNEXT
                         if (Permissions::PlayLocalMap() && UI::MenuItem(Icons::Play + " Play map")){
 #else
                         if (UI::MenuItem(Icons::Play + " Play map")){
 #endif
                             if (UI::IsOverlayShown() && Setting_CloseOverlayOnLoad) UI::HideOverlay();
-                            UI::ShowNotification("Loading map...", ColoredString(map.GbxMapName) + "\\$z\\$s by " + map.Username);
+                            UI::ShowNotification("Loading map...", Text::OpenplanetFormatCodes(map.GbxMapName) + "\\$z\\$s by " + map.Username);
                             MX::mapToLoad = map.TrackID;
                         }
                         if (!MX::APIDown && UI::MenuItem(Icons::Kenney::InfoCircle + " Open information")){
@@ -119,7 +119,7 @@ void RenderMenuMain(){
                         if (UI::MenuItem("\\$f00"+Icons::TrashO + " Remove map")){
                             g_PlayLaterMaps.RemoveAt(i);
                             SavePlayLater(g_PlayLaterMaps);
-                            UI::ShowNotification(ColoredString(map.GbxMapName) + "\\$z\\$s by " + map.Username + " has been removed!");
+                            UI::ShowNotification(Text::OpenplanetFormatCodes(map.GbxMapName) + "\\$z\\$s by " + map.Username + " has been removed!");
                         }
                         UI::EndMenu();
                     }
@@ -146,14 +146,14 @@ void RenderMenuMain(){
 
                     if (mapNadeo.MXMapInfo !is null) {
                         MX::MapInfo@ map = mapNadeo.MXMapInfo;
-                        if (UI::BeginMenu((Setting_ColoredMapName ? ColoredString(map.GbxMapName) : map.Name) + " \\$z\\$sby " + map.Username)) {
+                        if (UI::BeginMenu((Setting_ColoredMapName ? Text::OpenplanetFormatCodes(map.GbxMapName) : map.Name) + " \\$z\\$sby " + map.Username)) {
 #if TMNEXT
                             if (Permissions::PlayLocalMap() && UI::MenuItem(Icons::Play + " Play map")){
 #else
                             if (UI::MenuItem(Icons::Play + " Play map")){
 #endif
                                 if (UI::IsOverlayShown() && Setting_CloseOverlayOnLoad) UI::HideOverlay();
-                                UI::ShowNotification("Loading map...", ColoredString(map.GbxMapName) + " \\$zby " + map.Username);
+                                UI::ShowNotification("Loading map...", Text::OpenplanetFormatCodes(map.GbxMapName) + " \\$zby " + map.Username);
                                 MX::mapToLoad = map.TrackID;
                             }
                             if (!MX::APIDown && UI::MenuItem(Icons::Kenney::InfoCircle + " Open information")){
@@ -163,17 +163,17 @@ void RenderMenuMain(){
                             if (UI::MenuItem("\\$f00"+Icons::TrashO + " Remove map")){
                                 MXNadeoServicesGlobal::m_mapUidToAction = mapNadeo.uid;
                                 startnew(MXNadeoServicesGlobal::RemoveMapFromFavoritesAsync);
-                                UI::ShowNotification(ColoredString(mapNadeo.name) + " \\$zby " + map.Username + " has been removed from favorites!");
+                                UI::ShowNotification(Text::OpenplanetFormatCodes(mapNadeo.name) + " \\$zby " + map.Username + " has been removed from favorites!");
                             }
                             UI::EndMenu();
                         }
                     } else {
-                        if (UI::BeginMenu((Setting_ColoredMapName ? ColoredString(mapNadeo.name) : StripFormatCodes(mapNadeo.name)) + "\\$z" + (mapNadeo.authorUsername.Length > 0 ? (" by " + mapNadeo.authorUsername) : ""))) {
+                        if (UI::BeginMenu((Setting_ColoredMapName ? Text::OpenplanetFormatCodes(mapNadeo.name) : Text::StripFormatCodes(mapNadeo.name)) + "\\$z" + (mapNadeo.authorUsername.Length > 0 ? (" by " + mapNadeo.authorUsername) : ""))) {
                             UI::TextDisabled(Icons::Times + " This map is not available on " + pluginName);
                             if (UI::MenuItem("\\$f00"+Icons::TrashO + " Remove map")){
                                 MXNadeoServicesGlobal::m_mapUidToAction = mapNadeo.uid;
                                 startnew(MXNadeoServicesGlobal::RemoveMapFromFavoritesAsync);
-                                UI::ShowNotification(ColoredString(mapNadeo.name) + "\\$z" + (mapNadeo.authorUsername.Length > 0 ? (" by " + mapNadeo.authorUsername) : "") + " has been removed from favorites!");
+                                UI::ShowNotification(Text::OpenplanetFormatCodes(mapNadeo.name) + "\\$z" + (mapNadeo.authorUsername.Length > 0 ? (" by " + mapNadeo.authorUsername) : "") + " has been removed from favorites!");
                             }
                             UI::EndMenu();
                         }

--- a/src/Utils/MX/Classes/MapEmbeddedObject.as
+++ b/src/Utils/MX/Classes/MapEmbeddedObject.as
@@ -28,7 +28,7 @@ namespace MX
 
         void TryGetID()
         {
-            string url = "https://item.exchange/itemsearch/search?api=on&format=json&filename="+Name+"&authorlogin="+ObjectAuthor;
+            string url = "https://item.exchange/itemsearch/search?api=on&format=json&filename=" + Net::UrlEncode(Name) + "&authorlogin=" + Net::UrlEncode(ObjectAuthor);
             if (isDevMode) trace("MapEmbeddedObject::StartRequest (TryGetID): "+url);
             Net::HttpRequest@ req = API::Get(url);
             while (!req.Finished()) {

--- a/src/Utils/MX/Classes/Vehicle.as
+++ b/src/Utils/MX/Classes/Vehicle.as
@@ -1,0 +1,15 @@
+namespace MX
+{
+    class Vehicle
+    {
+        int ID;
+        string Name;
+
+        Vehicle(const int &in id, const string &in name)
+        {
+            if (isDevMode) trace("Loading Vehicle #"+id+" - "+name);
+            ID = id;
+            Name = name;
+        }
+    }
+}

--- a/src/Utils/MX/Methods.as
+++ b/src/Utils/MX/Methods.as
@@ -126,10 +126,11 @@ namespace MX
             if (m_environments.Length > 0) m_environments.RemoveRange(0, m_environments.Length);
             LoadEnvironments();
 #if MP4
-            if (repo == MP4mxRepos::Trackmania) {
-#endif
             if (m_vehicles.Length > 0) m_vehicles.RemoveRange(0, m_vehicles.Length);
             LoadVehicles();
+
+            if (repo == MP4mxRepos::Trackmania) {
+#endif
             if (m_leaderboardSeasons.Length > 0) m_leaderboardSeasons.RemoveRange(0, m_leaderboardSeasons.Length);
             GetAllLeaderboardSeasons();
 #if MP4

--- a/src/Utils/MX/Methods.as
+++ b/src/Utils/MX/Methods.as
@@ -17,6 +17,8 @@ namespace MX
                 m_mapTags.InsertLast(MapTag(resNet[i]));
             }
 
+            m_mapTags.Sort(function(a,b) { return a.Name < b.Name; });
+
             print(m_mapTags.Length + " tags loaded");
         } catch {
             throw("Error while loading tags");

--- a/src/Utils/MX/Methods.as
+++ b/src/Utils/MX/Methods.as
@@ -70,6 +70,51 @@ namespace MX
 #endif
     }
 
+    void LoadVehicles()
+    {
+#if MP4
+        if (repo == MP4mxRepos::Trackmania) {
+            m_vehicles.InsertLast(Vehicle(-1, "Any"));
+            m_vehicles.InsertLast(Vehicle(0, "Custom"));
+            m_vehicles.InsertLast(Vehicle(1, "CanyonCar"));
+            m_vehicles.InsertLast(Vehicle(2, "StadiumCar"));
+            m_vehicles.InsertLast(Vehicle(3, "ValleyCar"));
+            m_vehicles.InsertLast(Vehicle(4, "LagoonCar"));
+            m_vehicles.InsertLast(Vehicle(5, "DesertCar"));
+            m_vehicles.InsertLast(Vehicle(6, "SnowCar"));
+            m_vehicles.InsertLast(Vehicle(7, "RallyCar"));
+            m_vehicles.InsertLast(Vehicle(8, "CoastCar"));
+            m_vehicles.InsertLast(Vehicle(9, "BayCar"));
+            m_vehicles.InsertLast(Vehicle(10, "IslandCar"));
+            m_vehicles.InsertLast(Vehicle(11, "SpeedCarV2"));
+            m_vehicles.InsertLast(Vehicle(12, "TrafficCar"));
+            m_vehicles.InsertLast(Vehicle(13, "RallyCarUD"));
+            m_vehicles.InsertLast(Vehicle(14, "DesertCarUD"));
+            m_vehicles.InsertLast(Vehicle(15, "SnowCarUD"));
+            m_vehicles.InsertLast(Vehicle(16, "BayCarUD"));
+            m_vehicles.InsertLast(Vehicle(17, "IslandCarUD"));
+            m_vehicles.InsertLast(Vehicle(18, "CoastCarUD"));
+            m_vehicles.InsertLast(Vehicle(19, "StadiumCarUD"));
+            m_vehicles.InsertLast(Vehicle(20, "CanyonCarFlippy"));
+            m_vehicles.InsertLast(Vehicle(21, "Low-Gravity Car"));
+            m_vehicles.InsertLast(Vehicle(22, "StadiumUpsideDown"));
+            m_vehicles.InsertLast(Vehicle(23, "SpeedCar"));
+            m_vehicles.InsertLast(Vehicle(24, "AlpineCar"));
+            m_vehicles.InsertLast(Vehicle(25, "Vehi2"));
+            m_vehicles.InsertLast(Vehicle(26, "Vehi1"));
+        } else {
+            m_vehicles.InsertLast(Vehicle(1, "StormMan"));
+        }
+#elif TMNEXT
+        m_vehicles.InsertLast(Vehicle(-1, "Any"));
+        // m_vehicles.InsertLast(Vehicle(0, "Custom"));
+        m_vehicles.InsertLast(Vehicle(1, "CarSport"));
+        m_vehicles.InsertLast(Vehicle(2, "CarSnow"));
+        m_vehicles.InsertLast(Vehicle(3, "CarRally"));
+        m_vehicles.InsertLast(Vehicle(4, "CarDesert"));
+#endif
+    }
+
     void CheckForAPILoaded()
     {
         try {
@@ -81,6 +126,8 @@ namespace MX
 #if MP4
             if (repo == MP4mxRepos::Trackmania) {
 #endif
+            if (m_vehicles.Length > 0) m_vehicles.RemoveRange(0, m_vehicles.Length);
+            LoadVehicles();
             if (m_leaderboardSeasons.Length > 0) m_leaderboardSeasons.RemoveRange(0, m_leaderboardSeasons.Length);
             GetAllLeaderboardSeasons();
 #if MP4

--- a/src/Utils/MX/ModesFromMapType.as
+++ b/src/Utils/MX/ModesFromMapType.as
@@ -5,7 +5,10 @@ namespace MX
 
         // Trackmania
         json["Race"] = ""; // ManiaPlanet Map Type
-        json["TM_Race"] = ""; // TMNEXT Map Type
+        json["TM_Race"] = ""; // Base TMNEXT Map Type
+        json["TM_Stunt"] = "TrackMania/TM_StuntSolo_Local";
+        json["TM_Platform"] = "TrackMania/TM_Platform_Local";
+        json["TM_Royal"] = "TrackMania/TM_RoyalTimeAttack_Local";
 
         // Shootmania
         json["MeleeArena"] = ""; // Base Shootmania Map Type

--- a/src/Utils/MX/Parameters.as
+++ b/src/Utils/MX/Parameters.as
@@ -3,6 +3,7 @@ namespace MX
     array<MapTag@> m_mapTags;
     array<LeaderboardSeason@> m_leaderboardSeasons;
     array<Environment@> m_environments;
+    array<Vehicle@> m_vehicles;
 
     Net::HttpRequest@ req;
 

--- a/src/Utils/Methods.as
+++ b/src/Utils/Methods.as
@@ -15,6 +15,14 @@ CGameCtnChallenge@ GetCurrentMap(){
     return g_app.RootMap;
 }
 
+string CleanMapType(const string &in mapType) {
+    const int slashIndex = mapType.IndexOf("\\");
+
+    if (slashIndex == -1) return mapType;
+
+    return mapType.SubStr(slashIndex+1);
+}
+
 array<MX::MapInfo@> LoadPlayLater() {
     array<MX::MapInfo@> m_maps;
     Json::Value FileData = Json::FromFile(PlayLaterJSON);

--- a/src/Utils/NadeoServices.as
+++ b/src/Utils/NadeoServices.as
@@ -213,6 +213,25 @@ namespace MXNadeoServicesGlobal
         }
     }
 
+    Json::Value@ GetMapInfoAsync(const string &in mapUid)
+    {
+        string url = NadeoServices::BaseURLLive()+"/api/token/map/"+mapUid;
+        if (isDevMode) trace("NadeoServices - Get map information: " + url);
+        Net::HttpRequest@ req = NadeoServices::Get("NadeoLiveServices", url);
+        req.Start();
+        while (!req.Finished()) {
+            yield();
+        }
+        auto res = req.Json();
+
+        if (res.GetType() != Json::Type::Object) {
+            mxError("NadeoServices - Error getting map information: " + req.String());
+            return null;
+        }
+
+        return NadeoServices::MapInfo(res).ToJson();
+    }
+
     void AddMapToFavoritesAsync()
     {
         string url = NadeoServices::BaseURLLive()+"/api/token/map/favorite/"+m_mapUidToAction+"/add";

--- a/src/Utils/NadeoServices.as
+++ b/src/Utils/NadeoServices.as
@@ -64,7 +64,7 @@ namespace MXNadeoServicesGlobal
             for (uint i = 0; i < res["mapList"].Length; i++) {
                 string mapName = res["mapList"][i]["name"];
                 string mapUid = res["mapList"][i]["uid"];
-                if (isDevMode) trace("Loading favorite map #"+i+": " + StripFormatCodes(mapName) + " (" + mapUid + ")");
+                if (isDevMode) trace("Loading favorite map #"+i+": " + Text::StripFormatCodes(mapName) + " (" + mapUid + ")");
                 NadeoServices::MapInfo@ map = NadeoServices::MapInfo(res["mapList"][i]);
                 g_favoriteMaps.InsertLast(map);
             }
@@ -87,7 +87,7 @@ namespace MXNadeoServicesGlobal
                 for (uint i = 0; i < res["mapList"].Length; i++) {
                     string mapName = res["mapList"][i]["name"];
                     string mapUid = res["mapList"][i]["uid"];
-                    if (isDevMode) trace("Loading favorite map #"+i+": " + StripFormatCodes(mapName) + " (" + mapUid + ")");
+                    if (isDevMode) trace("Loading favorite map #"+i+": " + Text::StripFormatCodes(mapName) + " (" + mapUid + ")");
                     NadeoServices::MapInfo@ map = NadeoServices::MapInfo(res["mapList"][i]);
                     g_favoriteMaps.InsertLast(map);
                 }
@@ -150,12 +150,12 @@ namespace MXNadeoServicesGlobal
 
             for (uint i = 0; i < g_favoriteMaps.Length; i++) {
                 if (g_favoriteMaps[i].MXMapInfo !is null) {
-                    if (isDevMode) trace("NadeoServices - Author Username for "+StripFormatCodes(g_favoriteMaps[i].name)+" Skipping because MX map info is already loaded.");
+                    if (isDevMode) trace("NadeoServices - Author Username for "+Text::StripFormatCodes(g_favoriteMaps[i].name)+" Skipping because MX map info is already loaded.");
                     continue;
                 }
 
                 g_favoriteMaps[i].authorUsername = NadeoServices::GetDisplayNameAsync(g_favoriteMaps[i].author);
-                if (isDevMode) trace("NadeoServices - Author Username for "+StripFormatCodes(g_favoriteMaps[i].name)+" found: "+StripFormatCodes(g_favoriteMaps[i].authorUsername));
+                if (isDevMode) trace("NadeoServices - Author Username for "+Text::StripFormatCodes(g_favoriteMaps[i].name)+" found: "+Text::StripFormatCodes(g_favoriteMaps[i].authorUsername));
             }
 
             print("NadeoServices - Favorite maps: loaded "+g_favoriteMaps.Length+" maps." + (isDevMode ? (" NadeoServices total: " + g_totalFavoriteMaps + " maps.") :""));

--- a/src/Utils/NadeoServices/MapInfo.as
+++ b/src/Utils/NadeoServices/MapInfo.as
@@ -26,6 +26,7 @@ namespace NadeoServices
         string collectionName;
         int MXId;
         MX::MapInfo@ MXMapInfo;
+        Json::Value@ jsonCache;
 
         MapInfo(const Json::Value &in json)
         {
@@ -51,9 +52,45 @@ namespace NadeoServices
                 mapStyle = json["mapStyle"];
                 mapType = json["mapType"];
                 collectionName = json["collectionName"];
+
+                @jsonCache = ToJson();
             } catch {
                 mxWarn("Error parsing infos for map: " + name);
             }
+        }
+
+        Json::Value ToJson()
+        {
+            if (jsonCache !is null) return jsonCache;
+
+            Json::Value json = Json::Object();
+            try {
+                json["uid"] = uid;
+                json["mapId"] = mapId;
+                json["name"] = name;
+                json["author"] = author;
+                json["authorTime"] = authorTime;
+                json["goldTime"] = goldTime;
+                json["silverTime"] = silverTime;
+                json["bronzeTime"] = bronzeTime;
+                json["nbLaps"] = nbLaps;
+                json["valid"] = valid;
+                json["downloadUrl"] = downloadUrl;
+                json["thumbnailUrl"] = thumbnailUrl;
+                json["uploadTimestamp"] = uploadTimestamp;
+                json["updateTimestamp"] = updateTimestamp;
+                json["fileSize"] = fileSize;
+                json["public"] = public;
+                json["favorite"] = favorite;
+                json["playable"] = playable;
+                json["mapStyle"] = mapStyle;
+                json["mapType"] = mapType;
+                json["collectionName"] = collectionName;
+            } catch {
+                mxWarn("Error converting map info to json for map " + name);
+            }
+
+            return json;
         }
     }
 }

--- a/src/Utils/Renderables/ModalDialog.as
+++ b/src/Utils/Renderables/ModalDialog.as
@@ -35,8 +35,9 @@ class ModalDialog : IRenderable
         if (isOpen) {
             RenderDialog();
             UI::EndPopup();
-            UI::PopStyleVar(4);
         }
+
+        UI::PopStyleVar(4);
     }
 
     bool CanClose()

--- a/src/Utils/ServerUtils.as
+++ b/src/Utils/ServerUtils.as
@@ -14,6 +14,7 @@ namespace TMNext
 
     string AddMapToServer_MapUid = "";
     int AddMapToServer_MapMXId;
+    string AddMapToServer_MapType = "";
 
     void CheckNadeoRoomAsync() {
 #if DEPENDENCY_NADEOSERVICES && TMNEXT
@@ -69,6 +70,23 @@ namespace TMNext
             UploadMapToNadeoServices();
 
         trace("Adding map '" + AddMapToServer_MapUid + "' to Nadeo Room #"+AddMapToServer_ClubId+"-"+AddMapToServer_RoomId);
+
+        if (foundRoom.room.maps.Length > 0) {
+            const string mapUid = foundRoom.room.currentMapUid.Length > 0 ? foundRoom.room.currentMapUid : foundRoom.room.maps[0];
+            Json::Value mapInfo = MXNadeoServicesGlobal::GetMapInfoAsync(mapUid);
+
+            if (mapInfo is null) {
+                mxWarn("Couldn't find information for map UID " + mapUid, true);
+                return;
+            } else {
+                string serverMapType = CleanMapType(string(mapInfo["mapType"]));
+
+                if (serverMapType != AddMapToServer_MapType) {
+                    mxError("Map type doesn't match the room's current game mode", true);
+                    return;
+                }
+            }
+        }
 
         Json::Value bodyJson = Json::Object();
         if (AddMapToServer_PlayMapNow) {


### PR DESCRIPTION
# Gamemodes

### Add missing gamemodes for TM2020

Now the plugin can load royal, platform, and stunt maps.

### Check if the room's map type matches the map

TM2020 doesn't allow mixing gamemodes / map types, and mixing them through the API can cause different issues (Testings gave different results, but it usually breaks the room). Also needed to add a NadeoServices function to get the map information, and a ToJson method to the mapInfo class

<details>
<summary>Example</summary>

![image](https://github.com/user-attachments/assets/e5e88870-363a-4a90-9af6-3e7a36388143)

</details>

# UI

### Add alternate row colors for tables

<details>
<summary>Comparison</summary>

Before:
![image](https://github.com/user-attachments/assets/34afb58f-920e-4d3e-88c9-2d51c6e5c4be)


After:
![image](https://github.com/user-attachments/assets/1d7c3dd9-c257-43ae-b979-99dc8d36c63b)

</details>

### Set width for some combos

Two tabs were missing a set width for their combos

<details>
<summary>Comparison</summary>

Before:
![image](https://github.com/user-attachments/assets/e35f92a5-a50b-48d6-b323-5bd2d44e87da)

After:
![image](https://github.com/user-attachments/assets/84d23e35-9d15-4c2b-a900-d423bd9c7467)

</details>

### Align text for tables

Makes sure the text is vertically aligned in the table. Easier to notice with the awards column, as shown below

<details>
<summary>Comparison</summary>

Before:
![image](https://github.com/user-attachments/assets/077a86b1-6562-460d-8ada-dcb2e1b6730f)

After:
![image](https://github.com/user-attachments/assets/ed7714dd-a80a-4015-8813-a81e50e2d023)

</details>

### Render default tag color if the API doesn't return anything, render background even if there's only 1 tag

The MX API will return an empty string if the site uses the default tag color. Now, we try to parse the hex color passed by the API, and we use the default one if it failed. I also changed the default color to one that doesn't blend with the background, and made it so even 1 tag will render the background, since it would look misaligned otherwise (can see it in the comparison for maps with only 1 tag)

<details>
<summary>Comparison</summary>

Before:
![image](https://github.com/user-attachments/assets/8ad03319-1ae2-4c48-84db-7d2431484622)


After:
![image](https://github.com/user-attachments/assets/34004b03-5cb0-4484-9688-79b1f05b773b)


</details>

### Sort map tags alphabetically

MX sorts the tags alphabetically in the dropdown menu when filtering maps, and this makes it easier to find a specific tag

<details>
<summary>Comparison</summary>

Before:
![image](https://github.com/user-attachments/assets/819d1456-0afc-48f0-b990-acc274b03126)


After:
![image](https://github.com/user-attachments/assets/43c14df0-02c8-4851-96a4-a2c402c67e17)

</details>

### Use `TextWrapped` for "is this your profile" text in user tab

<details>
<summary>Comparison</summary>

Before:
![image](https://github.com/user-attachments/assets/9c6cb7fd-3550-4120-88ea-c3159b71f065)

After:
![image](https://github.com/user-attachments/assets/013b885b-d93c-49c4-b4c8-9f363011e17f)


</details>

### Only reload tag tab after header is closed

The header would automatically close itself and reload the tab each time you clicked a tag. This was not only annoying, but it would also freeze the game for a few secs if you clicked another tag before the previous request was finished, as observed in the comparison below. Now, we use a flag to know if we need to reload, and only do so if the user picked a tag

<details>
<summary>Comparison</summary>

Before:

https://github.com/user-attachments/assets/3a5e6769-83a0-4ffe-9ad0-35e12e7c94cf

After:

https://github.com/user-attachments/assets/f9443880-6915-48b6-a287-2e419ceda183

</details>

### Only render environment combo if the game has more than 1 environment

Avoids showing the environment combo for TM2020 and Shootmania

### Add vehicle combo

This makes it possible to filter the maps by its car, using all 26 cars available on MX (would be better if the API automatically gave this information). Like with the environment combo, it will only be rendered if there's more than 1 vehicle available, meaning it won't render for Shootmania

<details>
<summary>Image</summary>

![image](https://github.com/user-attachments/assets/11de0738-977a-4ab9-96dc-56ed049e0380)

</details>


### Render disabled button instead of text when map isn't uploaded to Nadeo services

Keeps consistency with other UI parts and it's easier to render compared to the text

<details>
<summary>Image</summary>

![image](https://github.com/user-attachments/assets/fcf9c95c-744a-4c36-a2a8-6c606a62eb7a)

</details>

# Other fixes

### Fix API call for embedded objects

If the object name had a space, it would fail. Ensure it works by using `UrlEncode` for the name and user

### Use correct variable for awards given maps section in an user tab

It would show the "load more" button even if there were no more maps to load

### Avoid using mode=2 for latest maps tab

This mode is only used in the MX frontpage because it only shows a single map per user, and the endpoint returns the latest maps by default anyway. Even MX doesn't use it in the latest maps page

### Update deprecated functions `ColoredString` and `StripFormatCodes` to the new functions

`ColoredString` was replaced by `Text::OpenplanetFormatCodes` and `StripFormatCodes` was added to the `Text` namespace

### Don't start request in tag tab if there's 0 tags selected

Avoids unnecessary API requests

### Use flag for replay leaderboard

Depending on ReplayCount can cause issues if a replay was added/removed from the leaderboard after the map was loaded in the plugin; mainly it will refresh it infinitely, and adding the fetched replays to the already existing ones, creating duplicated entries.

<details>
<summary>Example</summary>

![image](https://github.com/user-attachments/assets/d9c4721c-1d90-4a0e-a02d-404d025fbec8)

</details>

### Update access level in some texts

Small change, updates a few messages that mentioned standard access, which doesn't exist anymore

# Comment

Please let me know if any of the changes should be reverted or changed, I tried to not change stuff too much while still looking good

All the changes were tested on both TM2 and TM2020 (sadly I don't own Shootmania), but please test them if possible in case I missed something