### PR TITLE
Avoid refreshes if there's a request, reset page index

### DIFF
--- a/src/Interface/Tabs/MapList.as
+++ b/src/Interface/Tabs/MapList.as
@@ -162,6 +162,7 @@ class MapListTab : Tab
     {
         maps.RemoveRange(0, maps.Length);
         totalItems = 0;
+        m_page = 1;
     }
 
     void Reload() override

--- a/src/Interface/Tabs/MapList.as
+++ b/src/Interface/Tabs/MapList.as
@@ -153,7 +153,9 @@ class MapListTab : Tab
         }
         UI::SameLine();
         UI::SetCursorPos(vec2(UI::GetWindowSize().x - 40, UI::GetCursorPos().y));
+        UI::BeginDisabled(m_request !is null);
         if (UI::Button(Icons::Refresh)) Reload();
+        UI::EndDisabled();
     }
 
     void Clear()

--- a/src/Interface/Tabs/MapPackList.as
+++ b/src/Interface/Tabs/MapPackList.as
@@ -169,7 +169,9 @@ class MapPackListTab : Tab
         }
         UI::SameLine();
         UI::SetCursorPos(vec2(UI::GetWindowSize().x - 40, UI::GetCursorPos().y));
+        UI::BeginDisabled(m_request !is null);
         if (UI::Button(Icons::Refresh)) Reload();
+        UI::EndDisabled();
     }
 
     void Clear()

--- a/src/Interface/Tabs/MapPackList.as
+++ b/src/Interface/Tabs/MapPackList.as
@@ -178,6 +178,7 @@ class MapPackListTab : Tab
     {
         mapPacks.RemoveRange(0, mapPacks.Length);
         totalItems = 0;
+        m_page = 1;
     }
 
     void Reload() override


### PR DESCRIPTION
Noticed these 2 issues while testing other stuff with the plugin

* When clicking "Load more" in a list, it will increase the page index by one, but it wasn't being reset when the list was cleared. This would cause a softlock that required to reload the window/plugin, because any new request would include this value, making it skip maps (and if it didn't have that many pages, it would show nothing)
* If you try to reload a list while there's already a request going on, the game will freeze, requiring you to restart the game. Fixed by disabling the button while there's a request