### PR TITLE
Add better support for title packs and more game modes

### DIFF
--- a/src/Utils/MX/Methods.as
+++ b/src/Utils/MX/Methods.as
@@ -169,12 +169,6 @@ namespace MX
             }
             MX::MapInfo@ map = MX::MapInfo(json[0]);
 
-            string Mode = "";
-            Json::Value Modes = MX::ModesFromMapType();
-
-            if (Modes.HasKey(map.MapType)) {
-                Mode = Modes[map.MapType];
-            }
 #if TMNEXT
             if (Permissions::PlayLocalMap()) {
 #endif
@@ -189,17 +183,27 @@ namespace MX
                     && Permissions::OpenAdvancedMapEditor()
 #endif
                 ) app.ManiaTitleControlScriptAPI.EditMap("https://"+MXURL+"/maps/download/"+mapId, "", "");
-#if !MP4
-                else app.ManiaTitleControlScriptAPI.PlayMap("https://"+MXURL+"/maps/download/"+mapId, Mode, "");
-#else
                 else {
-                    if (Mode == "" && repo == MP4mxRepos::Trackmania) {
-                        Mode = "SingleMap";
+                    string Mode = "";
+                    Json::Value Modes = MX::ModesFromMapType();
+
+                    if (Modes.HasKey(map.MapType)) {
+                        Mode = Modes[map.MapType];
                     }
-                    app.ManiaTitleControlScriptAPI.PlayMap("https://"+MXURL+"/maps/download/"+mapId, Mode, "");
-                }
+
+#if MP4
+                    if (Mode == "" && repo == MP4mxRepos::Trackmania) {
+                        Json::Value TitlePackModes = MX::ModesFromTitlePack();
+                        const string loadedTP = CurrentTitlePack();
+
+                        if (TitlePackModes.HasKey(loadedTP)) {
+                            Mode = TitlePackModes[loadedTP];
+                        }
+                    }
 #endif
 
+                    app.ManiaTitleControlScriptAPI.PlayMap("https://"+MXURL+"/maps/download/"+mapId, Mode, "");
+                }
 #if TMNEXT
             } else mxError("You don't have permission to play custom maps.", true);
 #endif

--- a/src/Utils/MX/Methods.as
+++ b/src/Utils/MX/Methods.as
@@ -155,6 +155,13 @@ namespace MX
     void LoadMap(int mapId, bool intoEditor = false)
     {
         try {
+#if MP4
+            if (CurrentTitlePack() == "") {
+                mxError("You must select a title pack before opening a map", true);
+                return;
+            }
+#endif
+
             auto json = API::GetAsync("https://"+MXURL+"/api/maps/get_map_info/multi/"+mapId);
             if (json.Length == 0) {
                 mxError("Track not found.", true);

--- a/src/Utils/MX/ModesFromMapType.as
+++ b/src/Utils/MX/ModesFromMapType.as
@@ -3,9 +3,20 @@ namespace MX
     Json::Value ModesFromMapType(){
         Json::Value json = Json::Object();
 
-        // Trackmania
-        json["Race"] = ""; // ManiaPlanet Map Type
-        json["TM_Race"] = ""; // Base TMNEXT Map Type
+        // ManiaPlanet
+        json["Race"] = ""; // Base ManiaPlanet Map Type
+        json["TrackMania\\Race"] = "";
+        json["Platform"] = "";
+        json["Stunts"] = "";
+        json["GoalHuntArena"] = "GoalHunt";
+        json["HuntersArena"] = "Hunters";
+        json["PursuitArena"] = "Pursuit";
+        json["TMOne\\PlatformOneArena"] = "";
+        json["EW Stunts - Score Attack"] = "ExtraWorldSolo";
+        json["EW Race - Time Attack"] = "ExtraWorldSolo";
+
+        // TMNext
+        json["TM_Race"] = ""; // Base TMNext Map Type
         json["TM_Stunt"] = "TrackMania/TM_StuntSolo_Local";
         json["TM_Platform"] = "TrackMania/TM_Platform_Local";
         json["TM_Royal"] = "TrackMania/TM_RoyalTimeAttack_Local";

--- a/src/Utils/MX/ModesFromTitlePack.as
+++ b/src/Utils/MX/ModesFromTitlePack.as
@@ -1,0 +1,39 @@
+namespace MX
+{
+    Json::Value ModesFromTitlePack(){
+        Json::Value json = Json::Object();
+
+        // Base title packs
+        json["TMCanyon"] = "SingleMap";
+        json["TMStadium"] = "SingleMap";
+        json["TMValley"] = "SingleMap";
+        json["TMLagoon"] = "SingleMap";
+
+        // Envimix
+        json["TMAll"] = "SingleMap";
+        json["Envimix_Turbo"] = "EnvimixSolo";
+        json["Nadeo_Envimix"] = "EnvimixSolo";
+
+        // Environments recreations
+        // json["TMOneAlpine"] = "Unbitn/TMOne/TimeAttackOne";
+        // json["TMOneSpeed"] = "Unbitn/TMOne/TimeAttackOne";
+        // json["TMOneBay"] = "Unbitn/TMOne/TimeAttackOne";
+        json["TM2Rally"] = "GlobalSolo";
+        json["TM2U_Island"] = "SoloUni";
+        json["TM2_Coast"] = "CoastSolo";
+
+        // Gamemodes recreations
+        json["Platform"] = "PlatformSolo";
+        json["ExtraWorld"] = "ExtraWorldSolo";
+        json["ModePlus"] = "GlobalSolo";
+
+        // Competition
+        json["esl_comp"] = "SingleMap";
+
+        // Other
+        json["TMPlus_Canyon"] = "SingleMap";
+        json["TMPlus_Lagoon"] = "SingleMap";
+
+        return json;
+    }
+}

--- a/src/Utils/Methods.as
+++ b/src/Utils/Methods.as
@@ -23,6 +23,19 @@ string CleanMapType(const string &in mapType) {
     return mapType.SubStr(slashIndex+1);
 }
 
+string CurrentTitlePack() {
+    CTrackMania@ app = cast<CTrackMania>(GetApp());
+    if (app.LoadedManiaTitle is null) return "";
+
+    string titleId = app.LoadedManiaTitle.TitleId;
+
+#if MP4
+    return titleId.SubStr(0, titleId.IndexOf("@"));
+#else
+    return titleId;
+#endif
+}
+
 array<MX::MapInfo@> LoadPlayLater() {
     array<MX::MapInfo@> m_maps;
     Json::Value FileData = Json::FromFile(PlayLaterJSON);


### PR DESCRIPTION
## Explanation

For MP4, the plugin uses the "SingleMap" game mode for any title pack if the map type isn't supported / the mode in the JSON is an empty string. The issue with this is that, while SingleMap works for the base title packs and some community ones (e.g. TMAll), others title packs will never load the map if you pass "SingleMap" to it, because they use their own script instead.

This PR fixes this by using an empty string by default, and loading the default game mode through another JSON depending on the title pack. This allows maps to be loaded on title packs like TMOne Alpine, Platform, etc., and any other title pack that isn't included in the JSON that doesn't use SingleMap

The PR also adds some game modes to the list of supported ones, including the ones for Trackmania Galaxy, Platform, and Stunts

Finally, now we check if there's a title pack loaded before trying to open a map on MP4/SM, since the game won't load the map otherwise (The random map plugin already does something similar)

## Clarifications

* Platform, Stunts, and TrackMania\Race are empty strings because multiple title packs use these map types, so the game mode is decided by the title pack
* TMOne\PlatformOneArena is an empty string because the script used by the TMOne title packs is broken for non-campaign maps
* The TMOne title packs are commented out for the same reason
* The title packs JSON includes some unreleased title packs that were provided by Zai-tm

## Credits

Huge thanks to @zai-tm for providing the list of default game modes used by different title packs.