### PR TITLE
Sanitize download paths

### DIFF
--- a/src/Interface/Tabs/Map.as
+++ b/src/Interface/Tabs/Map.as
@@ -497,7 +497,9 @@ class MapTab : Tab
                 }
             } else {
                 UI::Text("\\$0f0" + Icons::Download + " \\$zMap downloaded");
-                UI::TextDisabled("to " + "Maps\\Downloaded\\"+pluginName+"\\" + m_map.TrackID + " - " + Path::SanitizeFileName(m_map.Name) + ".Map.Gbx");
+                UI::PushStyleColor(UI::Col::Text, UI::GetStyleColor(UI::Col::TextDisabled));
+                UI::TextWrapped("to " + "Maps\\Downloaded\\"+pluginName+"\\" + m_map.TrackID + " - " + Path::SanitizeFileName(m_map.Name) + ".Map.Gbx");
+                UI::PopStyleColor();
                 if (UI::RoseButton(Icons::FolderOpen + " Open Containing Folder")) OpenExplorerPath(IO::FromUserGameFolder("Maps/Downloaded/"+pluginName));
             }
         }

--- a/src/Interface/Tabs/Map.as
+++ b/src/Interface/Tabs/Map.as
@@ -497,7 +497,7 @@ class MapTab : Tab
                 }
             } else {
                 UI::Text("\\$0f0" + Icons::Download + " \\$zMap downloaded");
-                UI::TextDisabled("to " + "Maps\\Downloaded\\"+pluginName+"\\" + m_map.TrackID + " - " + m_map.Name + ".Map.Gbx");
+                UI::TextDisabled("to " + "Maps\\Downloaded\\"+pluginName+"\\" + m_map.TrackID + " - " + Path::SanitizeFileName(m_map.Name) + ".Map.Gbx");
                 if (UI::RoseButton(Icons::FolderOpen + " Open Containing Folder")) OpenExplorerPath(IO::FromUserGameFolder("Maps/Downloaded/"+pluginName));
             }
         }

--- a/src/Utils/MX/Methods.as
+++ b/src/Utils/MX/Methods.as
@@ -231,7 +231,7 @@ namespace MX
             if (mapPackName.Length > 0) {
                 mxDLFolder = mxDLFolder + "/Packs";
                 if (!IO::FolderExists(mxDLFolder)) IO::CreateFolder(mxDLFolder);
-                mxDLFolder = mxDLFolder + "/" + mapPackName;
+                mxDLFolder = mxDLFolder + "/" + Path::SanitizeFileName(mapPackName);
                 if (!IO::FolderExists(mxDLFolder)) IO::CreateFolder(mxDLFolder);
             }
 
@@ -244,6 +244,7 @@ namespace MX
             mapDownloadInProgress = false;
 
             if (_fileName.Length == 0) _fileName = map.TrackID + " - " + map.Name;
+            _fileName = Path::SanitizeFileName(_fileName);
             netMap.SaveToFile(mxDLFolder + "/" + _fileName + ".Map.Gbx");
             print("Map downloaded to " + mxDLFolder + "/" + _fileName + ".Map.Gbx");
         } catch {


### PR DESCRIPTION
Ran into this issue when trying to download a MP4 map, SaveToFile will raise an error that will be caught below, setting APIDown to true and requiring to reload the API

For example, if you try to download [this map](https://tm.mania.exchange/maps/249486/winter24-bonus-mep)

>  [   ScriptRuntime] [ TRAC] [16:57:46] [ManiaExchange]  Started downloading map ﻿Winter24 #??? - bonus mep (249486) to C:\Users\Fort\Documents\Maniaplanet\Maps/Downloaded/ManiaExchange
[   ScriptRuntime] [ERROR] [16:57:51] [ManiaExchange]  Error while downloading map
[   ScriptRuntime] [ERROR] [16:57:51] [ManiaExchange]  ManiaExchange API is not responding, it must be down.

I also changed the text in the UI for the download path to be wrapped, since it can be hard to read otherwise

<details>
<summary>Comparison</summary>

Before:
![image](https://github.com/user-attachments/assets/5c0ebcda-4b17-4bd0-8673-3f177fbd63b6)

After:
![image](https://github.com/user-attachments/assets/06adecdd-172c-4029-a3e0-5d24add2cbc1)


</details>

P.S.: Push/PopStyleColor are required because Begin/EndDisabled produce different colors, as I discovered today:

![image](https://github.com/user-attachments/assets/940967b1-752e-45b5-b49b-c7538b864af9)

I can use them anyway if it's preferred

